### PR TITLE
[MO] Fix: Registration flow

### DIFF
--- a/mobile/taskmanager/lib/app_bloc_observer.dart
+++ b/mobile/taskmanager/lib/app_bloc_observer.dart
@@ -1,0 +1,29 @@
+import 'dart:developer';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class AppBlocObserver extends BlocObserver {
+  @override
+  void onCreate(BlocBase bloc) {
+    super.onCreate(bloc);
+    log('${bloc.runtimeType}', name: "onCreate");
+  }
+
+  @override
+  void onChange(BlocBase bloc, Change change) {
+    super.onChange(bloc, change);
+    log('${bloc.runtimeType} ', name: "onChange");
+  }
+
+  @override
+  void onError(BlocBase bloc, Object error, StackTrace stackTrace) {
+    log('${bloc.runtimeType}, $error', name: "onError");
+    super.onError(bloc, error, stackTrace);
+  }
+
+  @override
+  void onClose(BlocBase bloc) {
+    super.onClose(bloc);
+    log('${bloc.runtimeType}', name: "onClose");
+  }
+}

--- a/mobile/taskmanager/lib/data/datasources/local/task_local.datasource.dart
+++ b/mobile/taskmanager/lib/data/datasources/local/task_local.datasource.dart
@@ -20,8 +20,7 @@ class TaskLocalDatasource {
 
   void syncTaskList(List<TaskModel> remoteTaskList) async {
     if (_taskStreamController.isClosed) return;
-    developer.log('Syncing task list with remote tasks',
-        name: 'TaskLocalDatasource');
+
     _tasks = remoteTaskList;
     _taskStreamController.add(_tasks);
   }
@@ -36,14 +35,11 @@ class TaskLocalDatasource {
       return;
     }
 
-    developer.log('Task ID not found: ${remoteTask.id}',
-        name: 'TaskLocalDatasource', level: 900);
     throw (Exception("ID not found - EditTask localTaskList"));
   }
 
   Future<void> deleteTask(int taskID) async {
     if (_taskStreamController.isClosed) return;
-    developer.log('Deleting task: $taskID', name: 'TaskLocalDatasource');
 
     final index = _tasks.indexWhere((task) => task.id == taskID);
 
@@ -53,26 +49,19 @@ class TaskLocalDatasource {
 
       return;
     }
-    developer.log('Task ID not found: $taskID',
-        name: 'TaskLocalDatasource', level: 900);
+
     throw (Exception("ID not found - RemoveTask localTaskList"));
   }
 
   Future<void> createTask(TaskModel taskFromRemote) async {
     if (_taskStreamController.isClosed) return;
-    developer.log('Creating task: ${taskFromRemote.id}',
-        name: 'TaskLocalDatasource');
 
     final index = _tasks.indexWhere((task) => task.id == taskFromRemote.id);
 
     if (index == -1) {
       _tasks.add(taskFromRemote);
-      developer.log('Task created: ${taskFromRemote.id}',
-          name: 'TaskLocalDatasource');
     } else {
       _tasks[index] = taskFromRemote;
-      developer.log('Task updated: ${taskFromRemote.id}',
-          name: 'TaskLocalDatasource');
     }
     _taskStreamController.add(_tasks);
   }

--- a/mobile/taskmanager/lib/data/datasources/local/user_local.datasource.dart
+++ b/mobile/taskmanager/lib/data/datasources/local/user_local.datasource.dart
@@ -46,7 +46,7 @@ class UserLocalDatasource {
     await _tokenBox.put(HiveConstant.userInfo, newUserInfo.toJsonString());
   }
 
-  UserModel? getUserInfo() {
+  Future<UserModel?> getUserInfo() async{
     final String? rawData = _tokenBox.get(HiveConstant.userInfo) as String?;
 
     if (rawData == null) {

--- a/mobile/taskmanager/lib/data/repositories/user.repository.dart
+++ b/mobile/taskmanager/lib/data/repositories/user.repository.dart
@@ -49,7 +49,7 @@ class UserRepository {
     return _localSource.getToken();
   }
 
-  UserModel? getUserInfo() {
+  Future<UserModel?> getUserInfo() {
     return _localSource.getUserInfo();
   }
 

--- a/mobile/taskmanager/lib/main.dart
+++ b/mobile/taskmanager/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';
+import 'package:taskmanager/app_bloc_observer.dart';
 import 'package:taskmanager/common/theme/palette.dart';
 import 'package:taskmanager/common/theme/text_style.dart';
 import 'package:taskmanager/common/theme/theme_sheet.dart';
@@ -28,6 +29,8 @@ void main() async {
 
 Future<void> initialize() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  Bloc.observer = AppBlocObserver();
 
   final appDir = await path_provider.getApplicationDocumentsDirectory();
   Hive.init(appDir.path);

--- a/mobile/taskmanager/lib/modules/auth/bloc/auth/auth_bloc.dart
+++ b/mobile/taskmanager/lib/modules/auth/bloc/auth/auth_bloc.dart
@@ -42,7 +42,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     _changeAuthState(tokenString, emit);
   }
 
-  void _setCredentials(AuthSetInfo event, Emitter<AuthState> emit) {
+  void _setCredentials(AuthSetInfo event, Emitter<AuthState>  emit) {
     _userRepository.setCredentials(event.userCredentials);
     _changeAuthState(event.userCredentials.token, emit);
   }

--- a/mobile/taskmanager/lib/modules/auth/bloc/register/register_event.dart
+++ b/mobile/taskmanager/lib/modules/auth/bloc/register/register_event.dart
@@ -3,9 +3,6 @@ part of 'register_bloc.dart';
 
 abstract class RegisterEvent extends Equatable {
   const RegisterEvent();
-
-  
-
   @override
   List<Object> get props => [];
 }

--- a/mobile/taskmanager/lib/modules/auth/view/register.view.dart
+++ b/mobile/taskmanager/lib/modules/auth/view/register.view.dart
@@ -16,14 +16,6 @@ class RegisterPage extends StatelessWidget {
   const RegisterPage({super.key});
 
   void _listenToStateChanges(BuildContext context, RegisterState state) {
-    if (state.status == StateStatus.success) {
-      Navigator.pushNamedAndRemoveUntil(
-        context,
-        "/home",
-        (route) => false,
-      );
-    }
-
     if (state.status == StateStatus.failed) {
       DialogHelper.showError(context,
           title: "Cannot register",

--- a/mobile/taskmanager/lib/modules/calendar/bloc/calendar_bloc.dart
+++ b/mobile/taskmanager/lib/modules/calendar/bloc/calendar_bloc.dart
@@ -1,6 +1,5 @@
 import 'dart:developer';
 
-
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:table_calendar/table_calendar.dart';
@@ -22,8 +21,6 @@ class CalendarBloc extends Bloc<CalendarEvent, CalendarState> {
 
   Future<void> _onOpen(CalendarOpen event, Emitter<CalendarState> emit) async {
     await emit.forEach(_taskRepo.getTaskStream(), onData: (taskList) {
-      log("UPDATED", name: "OnCalendarOpens");
-
       final filteredTask = taskList
           .where((task) => isSameDay(task.deadTime, state.selectedDate))
           .toList();

--- a/mobile/taskmanager/lib/modules/calendar/view/calendar.view.dart
+++ b/mobile/taskmanager/lib/modules/calendar/view/calendar.view.dart
@@ -8,11 +8,12 @@ import 'package:taskmanager/common/context_extension.dart';
 import 'package:taskmanager/common/widget/common_list_section.dart';
 
 import 'package:taskmanager/common/widget/common_title_appbar.widget.dart';
+import 'package:taskmanager/data/repositories/task.repository.dart';
+import 'package:taskmanager/main.dart';
 
 import 'package:taskmanager/modules/calendar/bloc/calendar_bloc.dart';
 import 'package:taskmanager/modules/calendar/widget/calendar_empty.widget.dart';
 import 'package:taskmanager/modules/calendar/widget/calendar_table.widget.dart';
-import 'package:taskmanager/modules/home/bloc/home_bloc.dart';
 
 import 'package:taskmanager/modules/task/view/task_list/task_list.view.dart';
 
@@ -21,7 +22,11 @@ class CalendarPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const CalendarView();
+    return BlocProvider<CalendarBloc>(
+      create: (context) => CalendarBloc(taskRepository: getIt<TaskRepository>())
+        ..add(const CalendarOpen()),
+      child: const CalendarView(),
+    );
   }
 }
 
@@ -37,19 +42,11 @@ class CalendarView extends StatelessWidget {
   }
 
   List<CommonListSection> _getSection(BuildContext context) {
-    if (context.read<CalendarBloc>().state.filteredTask.isEmpty &&
-        context.read<HomeBloc>().state.overdueList.isEmpty) {
+    if (context.read<CalendarBloc>().state.filteredTask.isEmpty) {
       return [];
     }
 
     return [
-      if (context.read<HomeBloc>().state.overdueList.isNotEmpty)
-        CommonListSection(
-          title: "Overdue",
-          child: TaskListPage(
-            taskList: context.read<HomeBloc>().state.overdueList,
-          ),
-        ),
       CommonListSection(
         title: DateFormat('dd MMM - EEEE')
             .format(context.read<CalendarBloc>().state.selectedDate),

--- a/mobile/taskmanager/lib/modules/home/bloc/home_bloc.dart
+++ b/mobile/taskmanager/lib/modules/home/bloc/home_bloc.dart
@@ -22,7 +22,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   final TaskRepository _taskRepository;
 
   Future<void> _onOpen(HomeOpen event, Emitter<HomeState> emit) async {
-    log("_onOpenRan!");
     emit(state.copyWith(status: StateStatus.loading));
     final DateTime today = DateTime.now();
     await emit.forEach<List<TaskModel>>(

--- a/mobile/taskmanager/lib/modules/home/view/home.view.dart
+++ b/mobile/taskmanager/lib/modules/home/view/home.view.dart
@@ -7,6 +7,8 @@ import 'package:taskmanager/common/widget/common_error.page.dart';
 import 'package:taskmanager/common/widget/common_list_section.dart';
 import 'package:intl/intl.dart';
 import 'package:taskmanager/common/widget/common_title_appbar.widget.dart';
+import 'package:taskmanager/data/repositories/task.repository.dart';
+import 'package:taskmanager/main.dart';
 
 import 'package:taskmanager/modules/home/bloc/home_bloc.dart';
 import 'package:taskmanager/modules/home/widget/home_empty.widget.dart';
@@ -20,12 +22,8 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiBlocProvider(
-      providers: [
-        BlocProvider.value(
-          value: BlocProvider.of<TaskListBloc>(context),
-        ),
-      ],
+    return BlocProvider<HomeBloc>(
+      create: (context) => HomeBloc(taskRepository: getIt<TaskRepository>()),
       child: const HomeView(),
     );
   }

--- a/mobile/taskmanager/lib/modules/navigation/view/navigation.view.dart
+++ b/mobile/taskmanager/lib/modules/navigation/view/navigation.view.dart
@@ -11,6 +11,7 @@ import 'package:taskmanager/modules/home/bloc/home_bloc.dart';
 
 import 'package:taskmanager/modules/home/view/home.view.dart';
 import 'package:taskmanager/modules/navigation/bloc/navigation_bloc.dart';
+import 'package:taskmanager/modules/navigation/widget/lazy_indexed_stack.dart';
 import 'package:taskmanager/modules/navigation/widget/navigation.widget.dart';
 import 'package:taskmanager/modules/profile/view/profile.view.dart';
 import 'package:taskmanager/modules/search/bloc/search_bloc.dart';
@@ -35,18 +36,6 @@ class NavigationPage extends StatelessWidget {
             return TaskListBloc(taskRepository: getIt<TaskRepository>());
           },
         ),
-        BlocProvider<HomeBloc>(
-          create: (context) =>
-              HomeBloc(taskRepository: getIt<TaskRepository>()),
-        ),
-        BlocProvider<SearchBloc>(
-            create: (context) =>
-                SearchBloc(taskRepository: getIt<TaskRepository>())
-                  ..add(const SearchOpen())),
-        BlocProvider<CalendarBloc>(
-            create: (context) =>
-                CalendarBloc(taskRepository: getIt<TaskRepository>())
-                  ..add(const CalendarOpen())),
       ],
       child: MultiBlocListener(
         listeners: [
@@ -109,13 +98,13 @@ class NavigationView extends StatelessWidget {
               child: const Icon(Icons.add),
             ),
             bottomNavigationBar: const NavigationWidget(),
-            body: IndexedStack(
+            body: LazyIndexedStack(
               index: state.index,
               children: const [
                 HomePage(),
                 CalendarPage(),
                 SearchPage(),
-                ProfilePage(),
+                ProfilePage()
               ],
             ));
       },

--- a/mobile/taskmanager/lib/modules/navigation/widget/lazy_indexed_stack.dart
+++ b/mobile/taskmanager/lib/modules/navigation/widget/lazy_indexed_stack.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/widgets.dart';
+
+class LazyIndexedStack extends StatefulWidget {
+  const LazyIndexedStack(
+      {super.key, required this.index, this.children = const []});
+
+  final int index;
+  final List<Widget> children;
+
+  @override
+  State<LazyIndexedStack> createState() => _LazyIndexedStackState();
+}
+
+class _LazyIndexedStackState extends State<LazyIndexedStack> {
+  late final List<bool> _activatedWidget;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _activatedWidget =
+        List.generate(widget.children.length, (i) => i == widget.index);
+  }
+
+  @override
+  void didUpdateWidget(covariant LazyIndexedStack oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.index != widget.index && !_activatedWidget[widget.index]) {
+      _activatedWidget[widget.index] = true;
+    }
+  }
+
+  List<Widget> get children {
+    return List.generate(
+        widget.children.length,
+        (i) => _activatedWidget[i] == true
+            ? widget.children[i]
+            : const SizedBox.shrink());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IndexedStack(
+      index: widget.index,
+      children: children,
+    );
+  }
+}

--- a/mobile/taskmanager/lib/modules/profile/bloc/profile_bloc.dart
+++ b/mobile/taskmanager/lib/modules/profile/bloc/profile_bloc.dart
@@ -17,11 +17,12 @@ class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
     add(const ProfileOpen());
   }
 
-  void _onProfileOpen(ProfileOpen event, Emitter<ProfileState> emit) {
+  Future<void> _onProfileOpen(
+      ProfileOpen event, Emitter<ProfileState> emit) async {
     emit(state.copyWith(status: StateStatus.loading));
 
     try {
-      final UserModel? userInfo = _userRepository.getUserInfo();
+      final UserModel? userInfo = await _userRepository.getUserInfo();
       if (userInfo == null) {
         emit(const ProfileState.failed(errorMessage: "Cannot get user info!"));
         return;

--- a/mobile/taskmanager/lib/modules/search/view/search.view.dart
+++ b/mobile/taskmanager/lib/modules/search/view/search.view.dart
@@ -4,6 +4,8 @@ import 'package:taskmanager/common/constants/state_status.constant.dart';
 import 'package:taskmanager/common/context_extension.dart';
 import 'package:taskmanager/common/widget/common_list_section.dart';
 import 'package:taskmanager/common/widget/common_title_appbar.widget.dart';
+import 'package:taskmanager/data/repositories/task.repository.dart';
+import 'package:taskmanager/main.dart';
 
 import 'package:taskmanager/modules/search/bloc/search_bloc.dart';
 import 'package:taskmanager/modules/search/widget/appbar_searchbar.widget.dart';
@@ -17,7 +19,11 @@ class SearchPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const SearchView();
+    return BlocProvider(
+      create: (context) => SearchBloc(taskRepository: getIt<TaskRepository>())
+        ..add(const SearchOpen()),
+      child: const SearchView(),
+    );
   }
 }
 

--- a/mobile/taskmanager/lib/modules/task/bloc/task_list/task_list.bloc.dart
+++ b/mobile/taskmanager/lib/modules/task/bloc/task_list/task_list.bloc.dart
@@ -51,8 +51,6 @@ class TaskListBloc extends Bloc<TaskListEvent, TaskListState> {
                 state.recentlyViewedTasks.any((recent) => recent.id == task.id))
             .toList();
 
-        log(newList.toString(), name: "Full list");
-
         return state.copyWith(
             status: StateStatus.success,
             recentlyViewedTasks: recentlyViewedTasksList);


### PR DESCRIPTION
### Known issues: 
- After registered, `NavigationBloc` and `TaskListBloc` called twice -> early disposure -> `HomePage` cannot load accordingly
- `ProfilePage` does not wait for user info to be loaded from local data source -> premature load error

### Changes:
- Remove listener on `RegistrationBloc` on success state
- Add `AppBlocObserver` to monitor blocs
- Implement `LazyIndexedStack` when loading pages through bottom navbar
- Add asynchronous loading for user information in `ProfilePage` 